### PR TITLE
Create CONTRIBUTING.MD

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,37 @@
+There are several ways you can participate in Demodam. 
+
+## Publish Common Ground components to Demodam
+Demodam is a showcase website for open source components. Please reach out to the Technical action team if you want to publish your components on Demodam. 
+
+## Take part in a hackathon
+During hackathons, Demodam is developed according to our goals: showcase, collaborate, improve, innovate. The first hackathon will be at 5-9 July. If you want to take part, please sign up for the [onboarding and planning session for the hackathon](https://www.meetup.com/Code-For-NL/events/278475015/).
+
+## Be active in Github
+Raise an issue, submit a pull request, etc. Be bold! 
+
+## Spread the word!
+Feel free to blog, tweet, post about '#demodam whenever you like! We're in this together. 
+
+## Take part in an action team
+
+The Demodam codebase forms action teams to solve specific tasks. These can make day to day decisions to move things forward, but cannot overrule decisions made by the steering team. Each action team must be represented in the steering group by at least one person (as a linking pin). If a team cannot resolve an issue with consensus in the group, any participant of the group can raise the issue to the steering team. Action teams have the mandate to take action whenever they think it helps Demodam and work on an "ask for forgiveness, not for permission" basis for now.
+
+### Communications action team
+Open group that works in a community style (there is likely to be a core team, that guides a wider community of participants and ambassadors). 
+    * Communicates milestones
+    * Share use cases
+    * Create guides, documentation, materials according to community needs
+    * Tries to find ambassadors at several levels
+    * Helps organize hackathons
+    * Social media, promotions, coverage, etc.
+    * **Members**: Alba Rosa (team lead), Edo Plantinga, Caroline?, Harrie Kuipers?, Ruud de Vries?
+### Technical action team
+    * Hosting setup
+    * How can several competing products all get a place on Demodam? (technical aspects of that)
+    * Advise (not decide) on acceptance criteria of components from a technical point of view (ie definition of done)
+    * **Members**: Ruben van der Linden (team lead), Joeri
+### User centricity action team
+    * Advise (not decide) on acceptance criteria from a  user centered design point of view (ie definition of done)
+    * Organize workshops before and during hackathons
+    * Advise on the design of demodam.nl itself (how are the needs of different stakeholders met?). Guide the user centered design process to achieve this. 
+    * **Members**: Under consideration (yet to be determined): Jeroen Vonk, Victor Zuydweg, Robbert, Edo Plantinga. If you want to be team lead for this team, please reach out to Edo. 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,37 +1,42 @@
-There are several ways you can participate in Demodam. 
+There are several ways you can participate in Demodam.
 
 ## Publish Common Ground components to Demodam
-Demodam is a showcase website for open source components. Please reach out to the Technical action team if you want to publish your components on Demodam. 
+Demodam is a showcase website for open source components. Please reach out to the Technical action team if you want to publish your components on Demodam.
 
 ## Take part in a hackathon
 During hackathons, Demodam is developed according to our goals: showcase, collaborate, improve, innovate. The first hackathon will be at 5-9 July. If you want to take part, please sign up for the [onboarding and planning session for the hackathon](https://www.meetup.com/Code-For-NL/events/278475015/).
 
 ## Be active in Github
-Raise an issue, submit a pull request, etc. Be bold! 
+Raise an issue, submit a pull request, etc. Be bold!
 
 ## Spread the word!
-Feel free to blog, tweet, post about '#demodam whenever you like! We're in this together. 
+Feel free to blog, tweet, post about Demodam whenever you like! We're in this together.
 
 ## Take part in an action team
 
 The Demodam codebase forms action teams to solve specific tasks. These can make day to day decisions to move things forward, but cannot overrule decisions made by the steering team. Each action team must be represented in the steering group by at least one person (as a linking pin). If a team cannot resolve an issue with consensus in the group, any participant of the group can raise the issue to the steering team. Action teams have the mandate to take action whenever they think it helps Demodam and work on an "ask for forgiveness, not for permission" basis for now.
 
 ### Communications action team
-Open group that works in a community style (there is likely to be a core team, that guides a wider community of participants and ambassadors). 
-    * Communicates milestones
-    * Share use cases
-    * Create guides, documentation, materials according to community needs
-    * Tries to find ambassadors at several levels
-    * Helps organize hackathons
-    * Social media, promotions, coverage, etc.
-    * **Members**: Alba Rosa (team lead), Edo Plantinga, Caroline?, Harrie Kuipers?, Ruud de Vries?
+Open group that works in a community style (there is likely to be a core team, that guides a wider community of participants and ambassadors).
+
+* Communicates milestones
+* Share use cases
+* Create guides, documentation, materials according to community needs
+* Tries to find ambassadors at several levels
+* Helps organize hackathons
+* Social media, promotions, coverage, etc.
+* **Members**: Alba Roza (team lead), Edo Plantinga, Caroline?, Harrie Kuipers?, Ruud de Vries?
+
 ### Technical action team
-    * Hosting setup
-    * How can several competing products all get a place on Demodam? (technical aspects of that)
-    * Advise (not decide) on acceptance criteria of components from a technical point of view (ie definition of done)
-    * **Members**: Ruben van der Linden (team lead), Joeri
+
+* Hosting setup
+* How can several competing products all get a place on Demodam? (technical aspects of that)
+* Advise (not decide) on acceptance criteria of components from a technical point of view (ie definition of done)
+* **Members**: Ruben van der Linden (team lead), Joeri
+
 ### User centricity action team
-    * Advise (not decide) on acceptance criteria from a  user centered design point of view (ie definition of done)
-    * Organize workshops before and during hackathons
-    * Advise on the design of demodam.nl itself (how are the needs of different stakeholders met?). Guide the user centered design process to achieve this. 
-    * **Members**: Under consideration (yet to be determined): Jeroen Vonk, Victor Zuydweg, Robbert, Edo Plantinga. If you want to be team lead for this team, please reach out to Edo. 
+
+* Advise (not decide) on acceptance criteria from a  user centered design point of view (ie definition of done)
+* Organize workshops before and during hackathons
+* Advise on the design of demodam.nl itself (how are the needs of different stakeholders met?). Guide the user centered design process to achieve this. 
+* **Members**: Under consideration (yet to be determined): Jeroen Vonk, Victor Zuydweg, Robbert, Edo Plantinga. If you want to be team lead for this team, please reach out to Edo. 


### PR DESCRIPTION
Fixes #8. As discussed in the meeting of 8 june 2021, with some elaborations. Renamed working groups to action teams, because working group sound too passive for what they are expected to do.